### PR TITLE
Fixing for node 4.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
 - '0.12'
+- '4.1.1'
 sudo: false
 after_success:
 - npm run report-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
 - '0.12'
-- '4.1.1'
+- '4.1'
 sudo: false
 after_success:
 - npm run report-coverage

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 
 var errors = require('./errors'),
 	fs = require('q-io/fs'),
+	nodeFs = require('fs' ),
 	path = require('path'),
 	Q = require('q'),
 	winston = require('winston');
@@ -281,7 +282,16 @@ function writeFile(output, filename, content) {
 
 	winston.info('\t%s', filename);
 
-	return fs.write(p, strContent);
+	// q-io is having issues writing in Node 4.1.1. Use node-native file writing instead.
+	var deferred = Q.defer();
+	nodeFs.writeFile(p, strContent, function(err) {
+		if(err) {
+			deferred.reject(err);
+		} else {
+			deferred.resolve();
+		}
+	} );
+	return deferred.promise;
 
 }
 


### PR DESCRIPTION
Not claiming this is the best fix, but it gets it working in the newest version of Node.
All the unit tests pass just fine, but the output files when it's run via CLI are empty, despite attempts to write the correct content to them.
This seems to be an issue with q-io, and using the Node-native FS module to write the file, in combination with Q's promises, resolves the issue.
